### PR TITLE
Add event subscriber that checks for a 'prerender' attribute on a request

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,14 +15,14 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
+                    - "8.1"
 
                 dependencies:
                     - "highest"
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
 
             -   name: "Setup PHP, with composer and extensions"
                 uses: "shivammathur/setup-php@v2"
@@ -32,7 +32,7 @@ jobs:
                     coverage: "none"
 
             -   name: "Install composer dependencies"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -55,13 +55,14 @@ jobs:
                 php-version:
                     - "7.4"
                     - "8.0"
+                    - "8.1"
 
                 dependencies:
                     - "highest"
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
 
             -   name: "Setup PHP, with composer and extensions"
                 uses: "shivammathur/setup-php@v2"
@@ -72,7 +73,7 @@ jobs:
                     tools: "composer-require-checker, composer-unused"
 
             -   name: "Install composer dependencies"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -92,13 +93,14 @@ jobs:
                 php-version:
                     - "7.4"
                     - "8.0"
+                    - "8.1"
 
                 dependencies:
                     - "highest"
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
 
             -   name: "Setup PHP, with composer and extensions"
                 uses: "shivammathur/setup-php@v2"
@@ -108,7 +110,7 @@ jobs:
                     coverage: "none"
 
             -   name: "Install composer dependencies"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -125,6 +127,7 @@ jobs:
                 php-version:
                     - "7.4"
                     - "8.0"
+                    - "8.1"
 
                 dependencies:
                     - "lowest"
@@ -132,7 +135,7 @@ jobs:
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
 
             -   name: "Setup PHP, with composer and extensions"
                 uses: "shivammathur/setup-php@v2"
@@ -142,7 +145,7 @@ jobs:
                     coverage: "none"
 
             -   name: "Install composer dependencies"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 
@@ -157,14 +160,14 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
+                    - "8.1"
 
                 dependencies:
                     - "highest"
 
         steps:
             -   name: "Checkout"
-                uses: "actions/checkout@v2"
+                uses: "actions/checkout@v3"
 
             -   name: "Setup PHP, with composer and extensions"
                 uses: "shivammathur/setup-php@v2"
@@ -177,7 +180,7 @@ jobs:
                 run: "echo \"::add-matcher::${{ runner.tool_cache }}/phpunit.json\""
 
             -   name: "Install composer dependencies"
-                uses: "ramsey/composer-install@v1"
+                uses: "ramsey/composer-install@v2"
                 with:
                     dependency-versions: "${{ matrix.dependencies }}"
 

--- a/composer-unused.php
+++ b/composer-unused.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use ComposerUnused\ComposerUnused\Configuration\Configuration;
+use ComposerUnused\ComposerUnused\Configuration\NamedFilter;
+
+return static function (Configuration $config): Configuration {
+    return $config
+        ->addNamedFilter(NamedFilter::fromString('symfony/http-client'))
+    ;
+};

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,21 @@
     ],
     "require": {
         "php": ">=7.4",
-        "symfony/config": "^4.4 || ^5.4",
-        "symfony/dependency-injection": "^4.4 || ^5.4",
-        "symfony/http-client": "^4.4.31 || ^5.4",
-        "symfony/http-client-contracts": "^2.4",
-        "symfony/http-foundation": "^4.4 || ^5.4",
-        "symfony/http-kernel": "^4.4 || ^5.4"
+        "league/uri": "^6.5",
+        "league/uri-components": "^2.4",
+        "setono/bot-detection-bundle": "^1.6",
+        "symfony/config": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-client": "^4.4.31 || ^5.4 || ^6.0",
+        "symfony/http-client-contracts": "^2.5 || ^3.0",
+        "symfony/http-foundation": "^4.4 || ^5.4 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.4 || ^6.0",
+        "webmozart/assert": "^1.10"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.3",
+        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16.1",
         "psalm/plugin-symfony": "^3.1",

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <psalm
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    totallyTyped="true"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorLevel="1"
 >
     <projectFiles>
         <directory name="src"/>
@@ -20,6 +20,7 @@
         <DeprecatedMethod>
             <errorLevel type="suppress">
                 <referencedMethod name="Symfony\Component\HttpFoundation\RequestStack::getMasterRequest"/>
+                <referencedMethod name="Symfony\Component\HttpKernel\Event\KernelEvent::isMasterRequest"/>
             </errorLevel>
         </DeprecatedMethod>
     </issueHandlers>

--- a/src/DependencyInjection/SetonoPrerenderExtension.php
+++ b/src/DependencyInjection/SetonoPrerenderExtension.php
@@ -23,6 +23,8 @@ final class SetonoPrerenderExtension extends Extension
         $container->setParameter('setono_prerender.prerenderer.rendertron.url', $config['prerenderer']['rendertron']['url']);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+
+        /** @psalm-suppress ReservedWord */
         $loader->load('services.xml');
     }
 }

--- a/src/EventSubscriber/PrerenderRequestSubscriber.php
+++ b/src/EventSubscriber/PrerenderRequestSubscriber.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PrerenderBundle\EventSubscriber;
+
+use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
+use Setono\PrerenderBundle\Prerenderer\PrerendererInterface;
+use Setono\PrerenderBundle\Request\MainRequestTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class PrerenderRequestSubscriber implements EventSubscriberInterface
+{
+    use MainRequestTrait;
+
+    private PrerendererInterface $prerenderer;
+
+    private BotDetectorInterface $botDetector;
+
+    public function __construct(PrerendererInterface $prerenderer, BotDetectorInterface $botDetector)
+    {
+        $this->prerenderer = $prerenderer;
+        $this->botDetector = $botDetector;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onRequest', 1900],
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$this->isMainRequest($event)) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        $prerenderAttribute = $request->attributes->get('prerender');
+        if (null === $prerenderAttribute) {
+            return;
+        }
+
+        if (!is_array($prerenderAttribute) && true !== $prerenderAttribute) {
+            return;
+        }
+
+        if (is_array($prerenderAttribute)) {
+            if (!isset($prerenderAttribute['bot']) || true !== $prerenderAttribute['bot']) {
+                return;
+            }
+
+            if (!$this->botDetector->isBotRequest($request)) {
+                return;
+            }
+        }
+
+        $event->setResponse(new Response($this->prerenderer->renderRequest($request)));
+        $event->stopPropagation();
+    }
+}

--- a/src/EventSubscriber/RemovePrerenderAttributeSubscriber.php
+++ b/src/EventSubscriber/RemovePrerenderAttributeSubscriber.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PrerenderBundle\EventSubscriber;
+
+use Setono\PrerenderBundle\Request\MainRequestTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class RemovePrerenderAttributeSubscriber implements EventSubscriberInterface
+{
+    use MainRequestTrait;
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onRequest', 2000],
+        ];
+    }
+
+    public function onRequest(RequestEvent $event): void
+    {
+        if (!$this->isMainRequest($event)) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        // this query parameter indicates that the current request is a prerender request
+        if (!$request->query->has('_is_prerender_request')) {
+            return;
+        }
+
+        $request->attributes->set('is_prerender_request', true);
+        $request->attributes->remove('prerender');
+    }
+}

--- a/src/Prerenderer/AbstractPrerenderer.php
+++ b/src/Prerenderer/AbstractPrerenderer.php
@@ -4,11 +4,18 @@ declare(strict_types=1);
 
 namespace Setono\PrerenderBundle\Prerenderer;
 
+use League\Uri\Contracts\UriInterface;
+use League\Uri\Uri;
+use League\Uri\UriModifier;
+use Psr\Http\Message\UriInterface as Psr7UriInterface;
+use Setono\PrerenderBundle\Request\MainRequestTrait;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 abstract class AbstractPrerenderer implements PrerendererInterface
 {
+    use MainRequestTrait;
+
     protected RequestStack $requestStack;
 
     public function __construct(RequestStack $requestStack)
@@ -26,9 +33,19 @@ abstract class AbstractPrerenderer implements PrerendererInterface
         return $this->renderUrl($request->getUri());
     }
 
+    public function renderUrl($url): string
+    {
+        return $this->_renderUrl(UriModifier::appendQuery(Uri::createFromString((string) $url), '_is_prerender_request'));
+    }
+
+    /**
+     * @param string|Psr7UriInterface|UriInterface $url
+     */
+    abstract protected function _renderUrl($url): string;
+
     private function getMainRequest(): Request
     {
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->getMainRequestFromRequestStack($this->requestStack);
         if (null === $request) {
             throw new \RuntimeException('You are not calling this method inside a request/response lifecycle');
         }

--- a/src/Prerenderer/Adapter/Rendertron.php
+++ b/src/Prerenderer/Adapter/Rendertron.php
@@ -22,10 +22,10 @@ final class Rendertron extends AbstractPrerenderer
         $this->rendertronUrl = rtrim($rendertronUrl, '/');
     }
 
-    public function renderUrl(string $url): string
+    protected function _renderUrl($url): string
     {
         return $this->httpClient
-            ->request('GET', sprintf('%s/render/%s', $this->rendertronUrl, rawurlencode($url)))
+            ->request('GET', sprintf('%s/render/%s', $this->rendertronUrl, rawurlencode((string) $url)))
             ->getContent()
         ;
     }

--- a/src/Prerenderer/PrerendererInterface.php
+++ b/src/Prerenderer/PrerendererInterface.php
@@ -4,14 +4,21 @@ declare(strict_types=1);
 
 namespace Setono\PrerenderBundle\Prerenderer;
 
+use Psr\Http\Message\UriInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 interface PrerendererInterface
 {
     /**
-     * Will render the given URL and return the HTML
+     * Will render the given URL and return the HTML.
+     *
+     * NOTICE: To avoid an infinite loop where a route with the prerender attribute is requesting to prerender itself
+     * add the _is_prerender_request query parameter to URLs sent to your Prerenderer Adapter. This is automatically
+     * handled if you extend the AbstractPrerenderer class
+     *
+     * @param string|UriInterface $url
      */
-    public function renderUrl(string $url): string;
+    public function renderUrl($url): string;
 
     /**
      * Will render the URL of the current request and return the HTML

--- a/src/Request/MainRequestTrait.php
+++ b/src/Request/MainRequestTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PrerenderBundle\Request;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Webmozart\Assert\Assert;
+
+trait MainRequestTrait
+{
+    public function getMainRequestFromRequestStack(RequestStack $requestStack): ?Request
+    {
+        $request = null;
+
+        if (method_exists($requestStack, 'getMainRequest')) {
+            /** @var Request|mixed|null $request */
+            $request = $requestStack->getMainRequest();
+        } elseif (method_exists($requestStack, 'getMasterRequest')) {
+            /** @var Request|mixed|null $request */
+            $request = $requestStack->getMasterRequest();
+        }
+
+        Assert::nullOrIsInstanceOf($request, Request::class);
+
+        return $request;
+    }
+
+    public function isMainRequest(KernelEvent $event): bool
+    {
+        $res = null;
+
+        if (method_exists($event, 'isMainRequest')) {
+            /** @var bool|mixed $res */
+            $res = $event->isMainRequest();
+        } elseif (method_exists($event, 'isMasterRequest')) {
+            /** @var bool|mixed $res */
+            $res = $event->isMasterRequest();
+        }
+
+        Assert::boolean($res);
+
+        return $res;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -3,6 +3,7 @@
 <container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
+        <import resource="services/event_subscriber.xml"/>
         <import resource="services/prerenderer.xml"/>
     </imports>
 </container>

--- a/src/Resources/config/services/event_subscriber.xml
+++ b/src/Resources/config/services/event_subscriber.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://symfony.com/schema/dic/services"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="setono_prerender.event_subscriber.prerender_request"
+                 class="Setono\PrerenderBundle\EventSubscriber\PrerenderRequestSubscriber">
+            <argument type="service" id="setono_prerender.prerenderer"/>
+            <argument type="service" id="setono_bot_detection.bot_detector.default"/>
+
+            <tag name="kernel.event_subscriber"/>
+        </service>
+
+        <service id="setono_prerender.event_subscriber.remove_prerender_attribute"
+                 class="Setono\PrerenderBundle\EventSubscriber\RemovePrerenderAttributeSubscriber">
+            <tag name="kernel.event_subscriber"/>
+        </service>
+    </services>
+</container>

--- a/tests/DependencyInjection/SetonoPrerenderExtensionTest.php
+++ b/tests/DependencyInjection/SetonoPrerenderExtensionTest.php
@@ -6,6 +6,7 @@ namespace Setono\PrerenderBundle\Tests\DependencyInjection;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 use Setono\PrerenderBundle\DependencyInjection\SetonoPrerenderExtension;
+use Setono\PrerenderBundle\Prerenderer\PrerendererInterface;
 
 /**
  * @covers \Setono\PrerenderBundle\DependencyInjection\SetonoPrerenderExtension
@@ -22,10 +23,22 @@ final class SetonoPrerenderExtensionTest extends AbstractExtensionTestCase
     /**
      * @test
      */
-    public function it_can_load(): void
+    public function it_registers_services(): void
     {
         $this->load();
 
-        self::assertTrue(true);
+        // event_subscriber.xml
+        $this->assertContainerBuilderHasService('setono_prerender.event_subscriber.prerender_request');
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('setono_prerender.event_subscriber.prerender_request', 'kernel.event_subscriber');
+
+        $this->assertContainerBuilderHasService('setono_prerender.event_subscriber.remove_prerender_attribute');
+        $this->assertContainerBuilderHasServiceDefinitionWithTag('setono_prerender.event_subscriber.remove_prerender_attribute', 'kernel.event_subscriber');
+
+        // prerenderer.xml
+        $this->assertContainerBuilderHasService(PrerendererInterface::class);
+        $this->assertContainerBuilderHasService('setono_prerender.prerenderer');
+        $this->assertContainerBuilderHasService('setono_prerender.prerenderer.rendertron');
+        $this->assertContainerBuilderHasAlias(PrerendererInterface::class, 'setono_prerender.prerenderer');
+        $this->assertContainerBuilderHasAlias('setono_prerender.prerenderer', 'setono_prerender.prerenderer.rendertron');
     }
 }

--- a/tests/EventSubscriber/PrerenderRequestSubscriberTest.php
+++ b/tests/EventSubscriber/PrerenderRequestSubscriberTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PrerenderBundle\Tests\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\BotDetectionBundle\BotDetector\BotDetectorInterface;
+use Setono\PrerenderBundle\EventSubscriber\PrerenderRequestSubscriber;
+use Setono\PrerenderBundle\EventSubscriber\RemovePrerenderAttributeSubscriber;
+use Setono\PrerenderBundle\Prerenderer\PrerendererInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\EventListener\DebugHandlersListener;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * @covers \Setono\PrerenderBundle\EventSubscriber\PrerenderRequestSubscriber
+ */
+final class PrerenderRequestSubscriberTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_sets_response_if_prerender_is_set_to_true(): void
+    {
+        $request = new Request([], [], ['prerender' => true]);
+
+        $prerenderer = $this->prophesize(PrerendererInterface::class);
+        $prerenderer->renderRequest($request)->willReturn('content');
+
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, 1);
+
+        $subscriber = new PrerenderRequestSubscriber(
+            $prerenderer->reveal(),
+            $this->prophesize(BotDetectorInterface::class)->reveal()
+        );
+        $subscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+
+        /** @psalm-suppress ReservedWord */
+        self::assertSame('content', $response->getContent());
+        self::assertTrue($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sets_response_if_prerender_is_array_and_bot_is_true(): void
+    {
+        $request = new Request([], [], ['prerender' => ['bot' => true]]);
+
+        $prerenderer = $this->prophesize(PrerendererInterface::class);
+        $prerenderer->renderRequest($request)->willReturn('content');
+
+        $botDetector = $this->prophesize(BotDetectorInterface::class);
+        $botDetector->isBotRequest($request)->willReturn(true);
+
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, 1);
+
+        $subscriber = new PrerenderRequestSubscriber(
+            $prerenderer->reveal(),
+            $botDetector->reveal()
+        );
+        $subscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNotNull($response);
+
+        /** @psalm-suppress ReservedWord */
+        self::assertSame('content', $response->getContent());
+        self::assertTrue($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_do_anything_if_prerender_attribute_is_not_present(): void
+    {
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), new Request(), 1);
+
+        $subscriber = new PrerenderRequestSubscriber(
+            $this->prophesize(PrerendererInterface::class)->reveal(),
+            $this->prophesize(BotDetectorInterface::class)->reveal()
+        );
+        $subscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNull($response);
+        self::assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_do_anything_if_prerender_attribute_is_false(): void
+    {
+        $request = new Request([], [], ['prerender' => false]);
+
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, 1);
+
+        $subscriber = new PrerenderRequestSubscriber(
+            $this->prophesize(PrerendererInterface::class)->reveal(),
+            $this->prophesize(BotDetectorInterface::class)->reveal()
+        );
+        $subscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNull($response);
+        self::assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_do_anything_if_prerender_attribute_is_array_and_bot_is_false(): void
+    {
+        $request = new Request([], [], ['prerender' => ['bot' => false]]);
+
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, 1);
+
+        $subscriber = new PrerenderRequestSubscriber(
+            $this->prophesize(PrerendererInterface::class)->reveal(),
+            $this->prophesize(BotDetectorInterface::class)->reveal()
+        );
+        $subscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNull($response);
+        self::assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function it_does_not_do_anything_if_request_is_not_a_bot(): void
+    {
+        $request = new Request([], [], ['prerender' => ['bot' => true]]);
+
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, 1);
+
+        $botDetector = $this->prophesize(BotDetectorInterface::class);
+        $botDetector->isBotRequest($request)->willReturn(false);
+
+        $subscriber = new PrerenderRequestSubscriber(
+            $this->prophesize(PrerendererInterface::class)->reveal(),
+            $botDetector->reveal()
+        );
+        $subscriber->onRequest($event);
+
+        $response = $event->getResponse();
+        self::assertNull($response);
+        self::assertFalse($event->isPropagationStopped());
+    }
+
+    /**
+     * @test
+     */
+    public function it_has_correct_priorities(): void
+    {
+        // fetching and validating events for the event subscriber we are testing
+        $ownEvents = PrerenderRequestSubscriber::getSubscribedEvents();
+        self::assertCount(1, $ownEvents);
+        self::assertArrayHasKey(KernelEvents::REQUEST, $ownEvents);
+
+        $ownPriority = $ownEvents[KernelEvents::REQUEST][1];
+        self::assertIsInt($ownPriority);
+
+        // fetching and validating events for the RemovePrerenderAttributeSubscriber
+        $removePrerenderAttributeSubscriberEvents = RemovePrerenderAttributeSubscriber::getSubscribedEvents();
+        self::assertCount(1, $removePrerenderAttributeSubscriberEvents);
+        self::assertArrayHasKey(KernelEvents::REQUEST, $removePrerenderAttributeSubscriberEvents);
+
+        $removePrerenderAttributeSubscriberPriority = $removePrerenderAttributeSubscriberEvents[KernelEvents::REQUEST][1];
+        self::assertIsInt($removePrerenderAttributeSubscriberPriority);
+        self::assertGreaterThan($ownPriority, $removePrerenderAttributeSubscriberPriority);
+
+        // fetching and validating events for the DebugHandlersListener
+        /** @psalm-suppress InternalClass,InternalMethod */
+        $debugHandlersListenerEvents = DebugHandlersListener::getSubscribedEvents();
+        self::assertArrayHasKey(KernelEvents::REQUEST, $debugHandlersListenerEvents);
+
+        $debugHandlersListenerPriority = $debugHandlersListenerEvents[KernelEvents::REQUEST][1];
+        self::assertIsInt($debugHandlersListenerPriority);
+        self::assertGreaterThan($ownPriority, $debugHandlersListenerPriority);
+    }
+}

--- a/tests/EventSubscriber/RemovePrerenderAttributeSubscriberTest.php
+++ b/tests/EventSubscriber/RemovePrerenderAttributeSubscriberTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PrerenderBundle\Tests\EventSubscriber;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Setono\PrerenderBundle\EventSubscriber\RemovePrerenderAttributeSubscriber;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * @covers \Setono\PrerenderBundle\EventSubscriber\RemovePrerenderAttributeSubscriber
+ */
+final class RemovePrerenderAttributeSubscriberTest extends TestCase
+{
+    use ProphecyTrait;
+
+    /**
+     * @test
+     */
+    public function it_removes_attribute(): void
+    {
+        $request = new Request(['_is_prerender_request' => true], [], ['prerender' => true]);
+
+        $event = new RequestEvent($this->prophesize(HttpKernelInterface::class)->reveal(), $request, 1);
+
+        $subscriber = new RemovePrerenderAttributeSubscriber();
+        $subscriber->onRequest($event);
+
+        self::assertFalse($request->attributes->has('prerender'));
+    }
+}

--- a/tests/Prerenderer/AbstractPrerendererTest.php
+++ b/tests/Prerenderer/AbstractPrerendererTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Setono\PrerenderBundle\Tests\Prerenderer;
+
+use PHPUnit\Framework\TestCase;
+use Setono\PrerenderBundle\Prerenderer\AbstractPrerenderer;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * @covers \Setono\PrerenderBundle\Prerenderer\AbstractPrerenderer
+ */
+final class AbstractPrerendererTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_renders_url(): void
+    {
+        $requestStack = new RequestStack();
+
+        $prerenderer = new Prerenderer($requestStack);
+        $prerenderer->renderUrl('https://example.com');
+
+        self::assertSame('https://example.com?_is_prerender_request', $prerenderer->renderedUrl);
+    }
+}
+
+final class Prerenderer extends AbstractPrerenderer
+{
+    public ?string $renderedUrl = null;
+
+    protected function _renderUrl($url): string
+    {
+        $this->renderedUrl = (string) $url;
+
+        return 'response';
+    }
+}


### PR DESCRIPTION
- [x] Avoid infinite loop when a request that asks for a prerender will request the same URL and then again request prerender and so on...
- [x] Add priority on subscriber, probably a very high priority so that it catches the request early